### PR TITLE
feat: add support for HTML content

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,6 +7,7 @@ const ACCEPTED_MIME_TYPES = [
 	"application/pdf",
 	"text/csv",
 	"text/plain",
+	"text/html",
 	"image/jpeg",
 	"image/bmp",
 	"image/gif",


### PR DESCRIPTION
This PR adds `text/html` mime type to allow support for HTML content.  Applications using this package can use `/upload` or `/upload-file` API to upload HTML content to IPFS.