### PR TITLE
feat(ipfs): add redirect and serve endpoints to cater for html content

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@ NODE_ENV=development
 PORT=3000
 
 # Sign up on https://www.mongodb.com/cloud/atlas for a free instance
-DATABASE_URL="mongodb+srv://<username>:<password>@<host-url>/<database-name>" 
+DATABASE_URL="mongodb+srv://<username>:<password>@<host-url>/<database-name>"
 
 IPFS_API="http://localhost:5001"
 IPFS_GATEWAY="http://localhost:8080"
+RECURSIVE_ENDPOINT="http://localhost:8081"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
 				"helmet": "^4.4.1",
 				"kubo-rpc-client": "^3.0.1",
 				"mongoose": "^7.3.1",
-				"multer": "^1.4.5-lts.1"
+				"multer": "^1.4.5-lts.1",
+				"node-fetch": "^3.3.2"
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.17",
@@ -1744,6 +1745,14 @@
 				"npm": ">=7.0.0"
 			}
 		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -2636,6 +2645,28 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2783,6 +2814,17 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
 			}
 		},
 		"node_modules/forwarded": {
@@ -3616,6 +3658,25 @@
 			"integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
 			"peerDependencies": {
 				"node-fetch": "*"
+			}
+		},
+		"node_modules/ipfs-utils/node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/is-array-buffer": {
@@ -4454,23 +4515,39 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
 		"node_modules/node-fetch": {
-			"version": "2.6.11",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-			"integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
 			"dependencies": {
-				"whatwg-url": "^5.0.0"
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
 			},
 			"engines": {
-				"node": "4.x || >=6.0.0"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
 			}
 		},
 		"node_modules/node-forge": {
@@ -5741,6 +5818,14 @@
 			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/webidl-conversions": {
@@ -7107,6 +7192,11 @@
 				}
 			}
 		},
+		"data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+		},
 		"debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -7787,6 +7877,15 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"requires": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			}
+		},
 		"file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -7902,6 +8001,14 @@
 			"requires": {
 				"cross-spawn": "^7.0.0",
 				"signal-exit": "^4.0.1"
+			}
+		},
+		"formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"requires": {
+				"fetch-blob": "^3.1.2"
 			}
 		},
 		"forwarded": {
@@ -8503,6 +8610,14 @@
 					"resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
 					"integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
 					"requires": {}
+				},
+				"node-fetch": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+					"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+					"requires": {
+						"whatwg-url": "^5.0.0"
+					}
 				}
 			}
 		},
@@ -9097,12 +9212,19 @@
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
 			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
 		},
+		"node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+		},
 		"node-fetch": {
-			"version": "2.6.11",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-			"integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
 			"requires": {
-				"whatwg-url": "^5.0.0"
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
 			}
 		},
 		"node-forge": {
@@ -10021,6 +10143,11 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+		},
+		"web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
 		},
 		"webidl-conversions": {
 			"version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
 		"helmet": "^4.4.1",
 		"kubo-rpc-client": "^3.0.1",
 		"mongoose": "^7.3.1",
-		"multer": "^1.4.5-lts.1"
+		"multer": "^1.4.5-lts.1",
+		"node-fetch": "^3.3.2"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.17",

--- a/src/models/Content.ts
+++ b/src/models/Content.ts
@@ -1,5 +1,5 @@
 import { type CID } from "kubo-rpc-client";
-import mongoose, { Schema } from "mongoose";
+import mongoose, { Schema, Document } from "mongoose";
 
 const ContentSchema = new Schema(
 	{
@@ -26,6 +26,14 @@ interface SaveDataArgs {
 	};
 }
 
+interface IContent extends Document {
+	cid: string;
+	pinned?: boolean;
+	metadata?: Record<string, unknown>;
+	createdAt?: Date;
+	updatedAt?: Date;
+}
+
 async function saveContentData({ cid, pinned, metadata }: SaveDataArgs): Promise<void> {
 	// each cid should have only one record
 	await ContentModel.findOneAndUpdate(
@@ -35,4 +43,8 @@ async function saveContentData({ cid, pinned, metadata }: SaveDataArgs): Promise
 	);
 }
 
-export { ContentModel, saveContentData };
+async function getContentData(cid: CID): Promise<IContent | null> {
+	return ContentModel.findOne({ cid:cid.toString() });
+}
+
+export { ContentModel, saveContentData, getContentData };

--- a/src/routes/ipfs.ts
+++ b/src/routes/ipfs.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 
-import { pin, unpin, upload, uploadFile } from "../controllers/ipfs";
+import {pin, unpin, upload, uploadFile, serve, getRecursivePreview} from "../controllers/ipfs";
 import { singleFileRequestHandler } from "../middlewares";
 
 const router = Router();
@@ -9,5 +9,19 @@ router.post("/upload", upload);
 router.post("/upload-file", singleFileRequestHandler("content"), uploadFile);
 router.put("/pin", pin);
 router.put("/unpin", unpin);
+router.get("/serve/:cid", serve);
+router.get("/content/:inscriptionId", getRecursivePreview);
+router.get("/r/blockhash", getRecursivePreview);
+router.get("/r/blockhash/:height", getRecursivePreview);
+router.get("/r/blockheight", getRecursivePreview);
+router.get("/r/blockinfo/:query", getRecursivePreview);
+router.get("/r/blocktime", getRecursivePreview);
+router.get("/r/children/:inscriptionId", getRecursivePreview);
+router.get("/r/children/:inscriptionId/:page", getRecursivePreview);
+router.get("/r/inscription/:inscriptionId", getRecursivePreview);
+router.get("/r/metadata/:inscriptionId", getRecursivePreview);
+router.get("/r/sat/:satNumber", getRecursivePreview);
+router.get("/r/sat/:satNumber/:page", getRecursivePreview)
+router.get("r/sat/:satNumber/at/:index", getRecursivePreview);
 
 export default { basePath: "/", router };


### PR DESCRIPTION
This PR adds 
1) A new endpoint, `ipfs/serve/:cid` to serve images from an IPFS gateway. This endpoint overrides the Content-Type header to ensure content are correctly served, addressing the issue where IPFS content identified as text/html was being incorrectly returned as text/plain.
2) Expanded endpoints to support HTML recursive previews of assets :
`/content/:inscriptionId`, `/r/blockhash`, `/r/blockhash/:height`, `/r/blockheight`, `/r/blockinfo/:query`, `/r/blocktime`, `/r/children/:inscriptionId`, `/r/children/:inscriptionId/:page`, `/r/inscription/:inscriptionId`, `/r/metadata/:inscriptionId`, `/r/sat/:satNumber`, `/r/sat/:satNumber/:page` and `r/sat/:satNumber/at/:index`
