### PR TITLE
fix(ipfs): set compress to false when fetching content from gateway

### DIFF
--- a/src/controllers/ipfs.ts
+++ b/src/controllers/ipfs.ts
@@ -152,7 +152,7 @@ async function serve(request: Request, response: Response, next: NextFunction) {
 		const cid = parseCID(request.params.cid);
 
 		const gatewayURL = generateGatewayURL(cid);
-		const asset =  await fetch(new URL(gatewayURL) )
+		const asset =  await fetch(new URL(gatewayURL) , { compress: false })
 
 		const assetHeaders = {...asset.headers.raw()}
 


### PR DESCRIPTION
This PR sets compress to false when fetching content from the ipfs gateway to respect the orginal content received from the gateway